### PR TITLE
Fixed runRoute failing on relative URI's

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -16,8 +16,10 @@ testUris :: [String]
 testUris =
   [ "https://test.com/root/4?param=hi"
   , "https://test.com/other/hi/"
+  , "/other/relativeMatch"
   , "https://test.com/fail"
   , "https://test.com/root/fail"
+  , "/root/relativeFail"
   ]
 
 main :: IO ()


### PR DESCRIPTION
Also added runRouteLoc which takes a Location instead, leaving String ->
Location parsing up to the user
Resolves #1 
