### PR TITLE
Bumped servant and uri-bytestring upper bounds

### DIFF
--- a/servant-router/servant-router.cabal
+++ b/servant-router/servant-router.cabal
@@ -17,11 +17,11 @@ library
   hs-source-dirs:      src
   exposed-modules:     Servant.Router
   build-depends:       base           >= 4.8 && < 5
-                     , servant        >= 0.7 && < 0.11
+                     , servant        >= 0.7 && < 0.12
                      , text           == 1.2.*
                      , http-api-data  >= 0.2 && < 0.4
                      , http-types     == 0.9.*
-                     , uri-bytestring == 0.2.*
+                     , uri-bytestring >= 0.2.0 && < 0.4
                      , bytestring     == 0.10.*
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
This makes package compatible with Stackage LTS 10