### PR TITLE
Only route pages when the full request path is consumed

### DIFF
--- a/servant-router/src/Servant/Router.hs
+++ b/servant-router/src/Servant/Router.hs
@@ -184,4 +184,6 @@ routeQueryAndPath queries pathSegs r = case r of
     [] -> return $ Left Fail
     p:paths ->
       if p == T.pack (symbolVal sym) then routeQueryAndPath queries paths a else return $ Left Fail
-  RPage a          -> Right <$> a
+  RPage a          -> case pathSegs of
+    [] -> Right <$> a
+    _ -> return $ Left Fail


### PR DESCRIPTION
After this change, servant-router more accurately reflects the
behavior of servant-server. Another benefit is that the ordering
of endpoints in the API becomes less relevant.

This is a breaking change for applications that depend on the
previous behavior which was similar to having an implicit
CaptureAll in front of every View.
